### PR TITLE
Fix login token generation

### DIFF
--- a/src/main/java/com/matchgo/quedamos/service/UserService.java
+++ b/src/main/java/com/matchgo/quedamos/service/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
             throw new BadCredentialsException("Email o contraseña incorrectos");
         }
 
-        String token = jwtService.generateToken(String.valueOf(user));
+        String token = jwtService.generateToken(user.getEmail());
         log.info("Login exitoso para: {}", user.getEmail());
 
         return token;


### PR DESCRIPTION
## Summary
- use the user's email when generating JWT tokens during login

## Testing
- `mvn -q test` *(fails: spring dependencies can't be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68839f1d5760832989ba044e1346a00c